### PR TITLE
sync update to oscal content

### DIFF
--- a/.github/workflows/sync_updates_to_oscal_content.yml
+++ b/.github/workflows/sync_updates_to_oscal_content.yml
@@ -1,14 +1,14 @@
 name: Sync CaC content to OSCAL
 on:
-  #pull_request:
-  #  types: [opened, synchronize, reopened]
-  #workflow_dispatch:
-  # The final version should execute the test whenever a PR is merged to master.
   pull_request:
-    types:
-      - closed
-    branches:
-      - master
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  # The final version should execute the test whenever a PR is merged to master.
+  #pull_request:
+  #  types:
+  #    - closed
+  #  branches:
+  #    - master
 
 jobs:
   check-pr-message:
@@ -229,8 +229,7 @@ jobs:
                       levels=$(echo "$map" | jq -r '.levels[]')
                       # Map the CAC profile and the OSCAL profile withe different level
                       for level in "${levels[@]}"; do
-                        oscal_profile=$policy_id"-"$level
-                        echo $oscal_profile
+                        oscal_profile=$product"-"$policy_id"-"$level
                         if [[ "$product" == *'rhel'* ]] ; then
                           type="software"
                         else
@@ -278,7 +277,7 @@ jobs:
                           else
                             type="service"
                           fi
-                          oscal_profile=$policy_id"-"$level
+                          oscal_profile=$product"-"$policy_id"-"$level
                           echo "Sync product $product component-definition according to the updated profile: $updated_profile........"
                           echo "poetry run trestlebot sync-cac-content component-definition --repo-path ../oscal-content --committer-email test@redhat.com --committer-name test --branch sync_cac_pr$pr_number --cac-content-root $GITHUB_WORKSPACE/cac-content --product $product  --component-definition-type $type --cac-profile $profile  --oscal-profile $oscal_profile"
                           sed -i '/href/s|\(trestle://\)[^ ]*\(catalogs\)|\1\2|g' ../oscal-content/profiles/$oscal_profile/profile.json
@@ -324,7 +323,7 @@ jobs:
               --title "Auto-generated PR from CAC $pr_number" \
               --head "$BRANCH_NAME" \
               --base "main" \
-              --body "This is an auto-generated PR from CAC $pr_number updates")
+              --body "This is an auto-generated PR from CAC $pr_number updates"
           fi
         env:
           GH_TOKEN: ${{ env.INSTALLATION_TOKEN }}


### PR DESCRIPTION
#### Description:

Add the workflow to sync the CAC content to OSCAL content

#### Rationale:

- Fixes CPLYTM-627

#### Review Hints:
This CI/CD relates to several repos:
[CAC content](https://github.com/complytime/cac-content)
[OSCAL content ](https://github.com/complytime/oscal-content)
[Trestlebot](https://github.com/complytime/trestle-bot)
[Content_test_filtering](https://github.com/ComplianceAsCode/content-test-filtering)
The steps of syncing CAC to OSCAL.
-  If the PR comes from OSCAL content, it will skip the following actions to avoid unnecessary loops.
-  Detect the CAC content update via [content-test-filtering PR](https://github.com/ComplianceAsCode/content-test-filtering/pull/51)
-  If the PR has some profiles and controls updates that will impact the OSCAL content, it will run the following actions
-  Set up the trestle-bot environment, cac-content, oscal-content
-  Get the github app installation access token of oscal-content
-  Get the mapping of the control, cac profile, oscal profile for each product
-  **Parse the CAC content update to the inputs of the trestle-bot sync-cac-content CLI and sync the content and push the update to OSCAL content.** 
-  Create PR to oscal-content

**I listed my questions:**
(It‘s out of date, but they are the reason to the step(Get the mapping of the control, cac profile, oscal profile for each product))
- When the pr has a **control** update, how to map which --cac-profile and --oscal-profile the component-definition will use? My thought: get mapping of the control, cac profile, oscal profile via a python script(shell is a little bit tricky).
- When the pr has a **profile** update, how to define the --oscal-profile the component-definition will use?  (The --oscal-profile is $$policy_id_level). My thought: Sync all the profiles for the Red Hat products to the OSCAL content first. Get a map of product profile and the oscal profile mapping.
- I [created a PR](https://github.com/complytime/trestle-bot/pull/516) to get the profiles, control files, and levels mapping. We could use this mapping to sync related component definitions.

Additional info:
**Run details:**
 - No detected cac updates: https://github.com/complytime/cac-content/actions/runs/14531793161/job/40772745422
 - Detected the controls updates: https://github.com/complytime/cac-content/actions/runs/14530398592/job/40769101643
 - Detected the controls and profiles updates: https://github.com/complytime/cac-content/actions/runs/14565914082/job/40855144512
- Detected the rules updates: Skip the rules sync that only need to update the rule title.
Any change in rules or variables content should not impact the transformation because for transformation we only need to know the ids and values used in control files and profiles.
There is a case if the rule title is changed. We use this field from rule.yml in the Component Definition. Only this case we need to do a sync. This update details won't in this CI, later it will be improved.

**Note**, all the syncs base on the inited the catalogs and profiles which are stored on the oscal-content side. The initial should be done after the stories: https://issues.redhat.com/browse/CPLYTM-702, what could tag the profiles for each product; https://issues.redhat.com/browse/CPLYTM-644 which component-definition is removing ANSSI and including CIS

- **The design and discussion doc is [here.]**(https://docs.google.com/document/d/1wby2E7yyoQBFAaRFcWyFr1HNod7726CO3Fs988pvPhM/edit?tab=t.0)

- **The CAC content update output  format as follows:**

`{"rules": ["dconf_gnome_enable_smartcard_auth", "dconf_gnome_disable_ctrlaltdel_reboot"], "product": "rhel8", "bash": "True", "ansible": "True"}
{"profiles": ["anssi_bp28_enhanced", "anssi_bp28_high", "default", "hipaa"], "product": "rhel10"}
{"profiles": ["default", "hipaa", "ospp", "cui"], "product": "rhel9"}
{"profiles": ["stig-v1r1"], "product": "ocp4"}
{"controls": ["anssi.yml", "section-1.yml", "SRG-OS-000080-GPOS-00048.yml"]}`
